### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
 #       run: find . -name docker-demo.jar
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: huangran/hr
         dockerfile: ./Dockerfile

--- a/.github/workflows/main_maven.yml
+++ b/.github/workflows/main_maven.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Publish to Registry
       run: mvn clean package dockerfile:build dockerfile:push -Ddockerfile.tag=v0.0.1
       
-#       uses: elgohr/Publish-Docker-Github-Action@master
+#       uses: elgohr/Publish-Docker-Github-Action@v5
 #       with:
 #         name: huangran/hr
 #         dockerfile: ./Dockerfile


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore